### PR TITLE
Add a `tabulate` dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         'petl',
         'livestats',
         'filelock',
-
+        'tabulate',
     ],
     extras_require={
         'geo': ['fiona', 'shapely','pyproj', 'pyproject']


### PR DESCRIPTION
Adding a `tabulate` dependency because without it the fresh install of `metatab` on Python 3.5 doesn't work:

```bash
$ pip install metatab
$ metatab -h
Traceback (most recent call last):
  File "/home/roll/projects/sandbox/.python/bin/metatab", line 9, in <module>
    load_entry_point('metatab==0.6.10', 'console_scripts', 'metatab')()
  File "/home/roll/projects/sandbox/.python/lib/python3.5/site-packages/pkg_resources/__init__.py", line 519, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/home/roll/projects/sandbox/.python/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2630, in load_entry_point
    return ep.load()
  File "/home/roll/projects/sandbox/.python/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2310, in load
    return self.resolve()
  File "/home/roll/projects/sandbox/.python/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2316, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/home/roll/projects/sandbox/.python/lib/python3.5/site-packages/metatab/__init__.py", line 9, in <module>
    from .parser import *
  File "/home/roll/projects/sandbox/.python/lib/python3.5/site-packages/metatab/parser.py", line 11, in <module>
    from rowgenerators import Source, get_generator
  File "/home/roll/projects/sandbox/.python/lib/python3.5/site-packages/rowgenerators/__init__.py", line 8, in <module>
    from .table import  Table, Column
  File "/home/roll/projects/sandbox/.python/lib/python3.5/site-packages/rowgenerators/table.py", line 9, in <module>
    from tabulate import tabulate
ImportError: No module named 'tabulate'
```